### PR TITLE
add release dependencies to mix.exs for exrm

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,12 @@ defmodule EredisCluster.Mixfile do
      deps: deps]
   end
 
+  def application do
+    [mod: {:eredis_cluster, []},
+     applications: [:eredis, :poolboy]
+    ]
+  end
+
   defp deps do
     [{:poolboy, "~> 1.5.1"},
       {:eredis, "~> 1.0.8"}]

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,2 @@
+%{"eredis": {:hex, :eredis, "1.0.8", "ab4fda1c4ba7fbe6c19c26c249dc13da916d762502c4b4fa2df401a8d51c5364", [:rebar], []},
+  "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []}}


### PR DESCRIPTION
Hi there!
I'm using eredis_cluster with Elixir, and build my app with [exrm](https://github.com/bitwalker/exrm).
But I found a dependency issue that my binary doesn't contain `eredis` and `poolboy` due to [the limitation of exrm](https://hexdocs.pm/exrm/common-issues.html#dependency-issues).

This PR will enable to build an app with exrm.
