### PR TITLE
0.5.11 tag name

### DIFF
--- a/src/eredis_cluster.app.src
+++ b/src/eredis_cluster.app.src
@@ -1,6 +1,6 @@
 {application, eredis_cluster, [
     {description, "Eredis Cluster"},
-    {vsn, "0.5.9"},
+    {vsn, "0.5.11"},
     {modules, []},
     {registered, []},
     {applications, [


### PR DESCRIPTION
I download the 0.5.10 tag from hex.pm, but it download and compile every time I restart my app. Here is the msg:
```
===> Upgrading eredis_cluster ({pkg,<<"eredis_cluster">>,<<"0.5.10">>,
                                       <<"144344C8D34058F249F5DA8CCCAC7F03AE77B2CCBC4CE55A99CE2DB7676BBB85">>})
```
And sometimes, it doesn't compile at all:
```
===> Failed to boot eredis_cluster for reason {"no such file or directory",
                                                          "eredis_cluster.app"}
```
I find out the eredis_clsuter dir not contains the `ebin` dir:
```
ls _build/default/lib/eredis_cluster
include  LICENSE  mix.exs  README.md  rebar.config  src  VERSION
```
I finally found out that, in the `src` file, the vesion is still 0.5.9, and since 0.5.10 is released and pushed to hex.pm, so I think the new tag name is 0.5.11, so is this patch.