### PR TITLE
Added replica support

### DIFF
--- a/include/eredis_cluster.hrl
+++ b/include/eredis_cluster.hrl
@@ -24,6 +24,7 @@
     start_slot :: integer(),
     end_slot :: integer(),
     index :: integer(),
+    type :: atom(),
     node :: #node{}
 }).
 

--- a/include/eredis_cluster.hrl
+++ b/include/eredis_cluster.hrl
@@ -25,7 +25,8 @@
     end_slot :: integer(),
     index :: integer(),
     type :: atom(),
-    node :: #node{}
+    node :: #node{},
+    replicas :: [#node{}]
 }).
 
 -define(REDIS_CLUSTER_HASH_SLOTS, 16384).

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,5 @@
-{erl_opts, [warnings_as_errors,
+{erl_opts, [{platform_define, "^17\.", 'ERLANG_OTP_VERSION_17'},
+            warnings_as_errors,
             warn_export_all]}.
 
 {xref_checks, [undefined_function_calls]}.

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -84,7 +84,7 @@ get_pool_by_slot(Slot, State, CommandType) ->
     Cluster =  case {CommandType, State#state.replica_read_flag}  of 
         {read, true} -> 
             ReadClusters = [Cluster || Cluster <- tuple_to_list(State#state.slots_maps), Cluster#slots_map.index == Index, Cluster#slots_map.type == replica],
-            lists:nth(rand:uniform(length(ReadClusters)), ReadClusters); %% Gets a random element from the read replicas
+            lists:nth(crypto:rand_uniform(0, length(ReadClusters)) + 1, ReadClusters); %% Gets a random element from the read replicas
         _ ->
             hd([Cluster || Cluster <- tuple_to_list(State#state.slots_maps), Cluster#slots_map.index == Index, Cluster#slots_map.type == master])
     end,    

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -288,7 +288,7 @@ connect_(InitNodes, ReplicaReadsFlag) ->
 init(_Args) ->
     ets:new(?MODULE, [protected, set, named_table, {read_concurrency, true}]),
     InitNodes = application:get_env(eredis_cluster, init_nodes, []),
-    ReplicaReadsFlag = case application:get_env(replica_read_flag, init_nodes, []) of 
+    ReplicaReadsFlag = case application:get_env(eredis_cluster, replica_read_flag, undefined) of 
         [] -> false;
         [true] -> true;
         true -> true;

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -191,7 +191,7 @@ parse_cluster_slots([[StartSlot, EndSlot | [[Address, Port | _] | ReplicaSlots]]
 parse_cluster_slots([], _Index, Acc, _) ->
     lists:reverse(Acc).
 
-parse_replica_slots([[Address, Port, _] | Slots], Index, {StartSlot, EndSlot}, Acc) ->
+parse_replica_slots([[Address, Port | _ ] | Slots], Index, {StartSlot, EndSlot}, Acc) ->
     ReplicaSlotsMaps = #slots_map{
         index = Index,
         type = replica,
@@ -203,6 +203,7 @@ parse_replica_slots([[Address, Port, _] | Slots], Index, {StartSlot, EndSlot}, A
         }
     },
     parse_replica_slots(Slots, Index, {StartSlot, EndSlot}, [ReplicaSlotsMaps | Acc]);
+
 parse_replica_slots([], _, _, Acc) ->
     Acc.  
 

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -12,6 +12,7 @@
 -export([get_all_master_pools/0]).
 -export([get_all_pools/0]).
 
+
 %% gen_server.
 -export([init/1]).
 -export([handle_call/3]).
@@ -20,8 +21,11 @@
 -export([terminate/2]).
 -export([code_change/3]).
 
+
+
 %% Type definition.
 -include("eredis_cluster.hrl").
+
 -record(state, {
     init_nodes :: [#node{}],
     slots :: tuple(), %% whose elements are integer indexes into slots_maps
@@ -84,7 +88,7 @@ get_pool_by_slot(Slot, State, CommandType) ->
     Cluster =  case {CommandType, State#state.replica_read_flag}  of 
         {read, true} -> 
             ReadClusters = [Cluster || Cluster <- tuple_to_list(State#state.slots_maps), Cluster#slots_map.index == Index, Cluster#slots_map.type == replica],
-            lists:nth(crypto:rand_uniform(0, length(ReadClusters)) + 1, ReadClusters); %% Gets a random element from the read replicas
+            lists:nth(util:get_random_number(length(ReadClusters)), ReadClusters); %% Gets a random element from the read replicas
         _ ->
             hd([Cluster || Cluster <- tuple_to_list(State#state.slots_maps), Cluster#slots_map.index == Index, Cluster#slots_map.type == master])
     end,    

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -88,7 +88,7 @@ get_pool_by_slot(Slot, State, CommandType) ->
     Cluster =  case {CommandType, State#state.replica_read_flag}  of 
         {read, true} -> 
             ReadClusters = [Cluster || Cluster <- tuple_to_list(State#state.slots_maps), Cluster#slots_map.index == Index, Cluster#slots_map.type == replica],
-            lists:nth(util:get_random_number(length(ReadClusters)), ReadClusters); %% Gets a random element from the read replicas
+            lists:nth(eredis_cluster_util:get_random_number(length(ReadClusters)), ReadClusters); %% Gets a random element from the read replicas
         _ ->
             hd([Cluster || Cluster <- tuple_to_list(State#state.slots_maps), Cluster#slots_map.index == Index, Cluster#slots_map.type == master])
     end,    

--- a/src/eredis_cluster_pool.erl
+++ b/src/eredis_cluster_pool.erl
@@ -81,8 +81,7 @@ stop(PoolName) ->
 
 -spec get_name(Host::string(), Port::integer()) -> PoolName::atom().
 get_name(Host, Port) ->
-    Random = eredis_cluster_util:get_random_number(100000),
-    list_to_atom(Host ++ "#" ++ integer_to_list(Port) ++ integer_to_list(Random)). %% Generate a random name for the pool
+    list_to_atom(Host ++ "#" ++ integer_to_list(Port)). %% Generate a random name for the pool
 
 -spec start_link() -> {ok, pid()}.
 start_link() ->

--- a/src/eredis_cluster_pool.erl
+++ b/src/eredis_cluster_pool.erl
@@ -81,7 +81,7 @@ stop(PoolName) ->
 
 -spec get_name(Host::string(), Port::integer()) -> PoolName::atom().
 get_name(Host, Port) ->
-    Random = util:get_random_number(100000),
+    Random = eredis_cluster_util:get_random_number(100000),
     list_to_atom(Host ++ "#" ++ integer_to_list(Port) ++ integer_to_list(Random)). %% Generate a random name for the pool
 
 -spec start_link() -> {ok, pid()}.

--- a/src/eredis_cluster_pool.erl
+++ b/src/eredis_cluster_pool.erl
@@ -1,6 +1,7 @@
 -module(eredis_cluster_pool).
 -behaviour(supervisor).
 
+
 %% API.
 -export([create/2]).
 -export([stop/1]).
@@ -80,7 +81,7 @@ stop(PoolName) ->
 
 -spec get_name(Host::string(), Port::integer()) -> PoolName::atom().
 get_name(Host, Port) ->
-    Random = crypto:rand_uniform(1, 100000),
+    Random = util:get_random_number(100000),
     list_to_atom(Host ++ "#" ++ integer_to_list(Port) ++ integer_to_list(Random)). %% Generate a random name for the pool
 
 -spec start_link() -> {ok, pid()}.

--- a/src/eredis_cluster_pool.erl
+++ b/src/eredis_cluster_pool.erl
@@ -80,8 +80,8 @@ stop(PoolName) ->
 
 -spec get_name(Host::string(), Port::integer()) -> PoolName::atom().
 get_name(Host, Port) ->
-    Random = rand:uniform(100000),
-    list_to_atom(Host ++ "#" ++ integer_to_list(Port) ++ integer_to_list(Random)).
+    Random = crypto:rand_uniform(1, 100000),
+    list_to_atom(Host ++ "#" ++ integer_to_list(Port) ++ integer_to_list(Random)). %% Generate a random name for the pool
 
 -spec start_link() -> {ok, pid()}.
 start_link() ->

--- a/src/eredis_cluster_pool.erl
+++ b/src/eredis_cluster_pool.erl
@@ -80,7 +80,7 @@ stop(PoolName) ->
 
 -spec get_name(Host::string(), Port::integer()) -> PoolName::atom().
 get_name(Host, Port) ->
-    Random = random:uniform(100000),
+    Random = rand:uniform(100000),
     list_to_atom(Host ++ "#" ++ integer_to_list(Port) ++ integer_to_list(Random)).
 
 -spec start_link() -> {ok, pid()}.

--- a/src/eredis_cluster_util.erl
+++ b/src/eredis_cluster_util.erl
@@ -1,4 +1,4 @@
--module(util).
+-module(eredis_cluster_util).
 
 -export([get_random_number/1]).
 

--- a/src/util.erl
+++ b/src/util.erl
@@ -1,0 +1,9 @@
+-module(util).
+
+-export([get_random_number/1]).
+
+-ifdef(ERLANG_OTP_VERSION_17).
+get_random_number(N) -> random:seed(now()), random:uniform(N).
+-else.
+get_random_number(N) -> rand:uniform(N).
+-endif.

--- a/test.config
+++ b/test.config
@@ -8,6 +8,6 @@
         {pool_max_overflow, 0},
         {database, 0},
         {password, ""},
-        {read_replica_flag, true}
+        {replica_read_flag, true}
     ]
 }].

--- a/test.config
+++ b/test.config
@@ -7,6 +7,7 @@
         {pool_size, 5},
         {pool_max_overflow, 0},
         {database, 0},
-        {password, ""}
+        {password, ""},
+        {read_replica_flag, true}
     ]
 }].


### PR DESCRIPTION
This PR accomplishes sending the read queries to the replicas.
This is managed via specifying a read_replica_flag during the connection process, or alternatively specifying the same in the env args.
Depending on the state of the read replica flags, additional pools are maintained which connects to the replica nodes, and based on the type of queries appropriate pool is chosen and the query is sent to the node. 
The query used for the replica are:
        zrange
        touch
        zrevrangebylex
        dump
        zcount
        hmget
        hgetall
        sinter
        georadius_ro
        exists
        zrevrank
        zrangebyscore
        dbsize
        lrange
        type
        zlexcount
        zrank
        llen
        geodist
        bitcount
        zrangebylex
        sdiff
        hscan
        hexists
        randomkey
        zrevrangebyscore
        zrevrange
        pttl
        zcard
        ttl
        zscore
        smembers
        scan
        substr
        geohash
        georadiusbymember_ro
        geopos
        getrange
        strlen
        sscan
        hkeys
        sismember
        hstrlen
        mget
        get
        srandmember
        hvals
        psync
        sync
        object
        pfcount
        bitpos
        lindex
        keys
        getbit
        memory
        scard
        zscan
        hget
        sunion
        hlen
(I have used filtered out the readonly commands which can be obtained using the `COMMANDS` function in redis).
EVAL and MULTI EXEC are sent to the master by default. Also everything associate with optimistic locking transaction is sent to the master nodes. 
The API's are backward compatible as you have to specify the read_replica_flag during the startup. 