### PR TITLE
Fix #28

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -12,5 +12,6 @@
              {preprocess, true}]}.
 
 {deps, [{eredis, "1.2.0"},
-       {poolboy, "1.5.2"}
+       {poolboy, "1.5.2"},
+        {worker_pool, {git, "https://github.com/inaka/worker_pool", {branch, "master"}}}
        ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,10 @@
 {"1.1.0",
 [{<<"eredis">>,{pkg,<<"eredis">>,<<"1.2.0">>},0},
- {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.2">>},0}]}.
+ {<<"poolboy">>,{pkg,<<"poolboy">>,<<"1.5.2">>},0},
+ {<<"worker_pool">>,
+  {git,"https://github.com/inaka/worker_pool",
+       {ref,"fc4ae9799588e7922a9d5411dfff728dd9688a07"}},
+  0}]}.
 [
 {pkg_hash,[
  {<<"eredis">>, <<"0B8E9CFC2C00FA1374CD107EA63B49BE08D933DF2CF175E6A89B73DD9C380DE4">>},

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -194,6 +194,7 @@ handle_transaction_result(Result, Version) ->
        % If we detect a node went down, we should probably refresh the slot
         % mapping.
         {error, no_connection} ->
+            logger:error("eredis_cluster:handle_transaction_result <--> {error, no_connection}",[]),
             eredis_cluster_monitor:refresh_mapping(Version),
             retry;
 
@@ -202,11 +203,13 @@ handle_transaction_result(Result, Version) ->
         % the next request. We don't need to refresh the slot mapping in this
         % case
         {error, tcp_closed} ->
+            logger:error("eredis_cluster:handle_transaction_result <--> {error, no_connection}",[]),
             retry;
 
         % Redis explicitly say our slot mapping is incorrect, we need to refresh
         % it
         {error, <<"MOVED ", _/binary>>} ->
+            logger:error("eredis_cluster:handle_transaction_result <--> {error, MOVED} Result = ~",[Result]),
             eredis_cluster_monitor:refresh_mapping(Version),
             retry;
 

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -195,7 +195,7 @@ handle_transaction_result(Result, Version) ->
         % mapping.
         {error, no_connection} ->
             logger:error("eredis_cluster:handle_transaction_result <--> {error, no_connection}",[]),
-            %%eredis_cluster_monitor:refresh_mapping(Version),
+            eredis_cluster_monitor:refresh_mapping(Version),
             retry;
 
         % If the tcp connection is closed (connection timeout), the redis worker

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -102,8 +102,11 @@ qmn(Commands, Counter) ->
     end.
 
 qmn2([{Pool, PoolCommands} | T1], [{Pool, Mapping} | T2], Acc, Version) ->
-    Transaction = fun(Worker) -> qw(Worker, PoolCommands) end,
-    Result = eredis_cluster_pool:transaction(Pool, Transaction),
+    Worker = eredis_cluster_pool:get_worker(Pool),
+    WorkerPID = whereis(Worker),
+
+    Result = eredis:q(WorkerPID,PoolCommands,5000),
+
     case handle_transaction_result(Result, Version, check_pipeline_result) of
         retry -> retry;
         Res -> 

--- a/src/eredis_cluster.erl
+++ b/src/eredis_cluster.erl
@@ -195,7 +195,7 @@ handle_transaction_result(Result, Version) ->
         % mapping.
         {error, no_connection} ->
             logger:error("eredis_cluster:handle_transaction_result <--> {error, no_connection}",[]),
-            eredis_cluster_monitor:refresh_mapping(Version),
+            %%eredis_cluster_monitor:refresh_mapping(Version),
             retry;
 
         % If the tcp connection is closed (connection timeout), the redis worker
@@ -204,6 +204,10 @@ handle_transaction_result(Result, Version) ->
         % case
         {error, tcp_closed} ->
             logger:error("eredis_cluster:handle_transaction_result <--> {error, no_connection}",[]),
+            retry;
+
+        {error, retry} ->
+            logger:error("eredis_cluster:handle_transaction_result <--> {error, retry}",[]),
             retry;
 
         % Redis explicitly say our slot mapping is incorrect, we need to refresh

--- a/src/eredis_cluster_pool_worker.erl
+++ b/src/eredis_cluster_pool_worker.erl
@@ -38,6 +38,8 @@ init(Args) ->
 
     {ok, #state{conn=Conn}}.
 
+query(full, _Commands) ->
+    {error, retry};
 query(Worker, Commands) ->
     gen_server:call(Worker, {'query', Commands}).
 


### PR DESCRIPTION
Avoid error in function eredis_cluster_pool_worker:query() when poolboy return full instead of a Worker PID because pool is full