### PR TITLE
Improve query handling

### DIFF
--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -178,24 +178,14 @@ basic_test_() ->
                 Key = "{1}:test",
                 eredis_cluster:q(["set",Key]),
                 {ok, NodesInfo} = eredis_cluster:q(["cluster","nodes"]),
-                OTPRel = list_to_integer(erlang:system_info(otp_release)),
 
-                ClusterNodesList = case OTPRel < 20 of
-                                       true ->  string:tokens(NodesInfo,"\n");
-                                       false -> string:lexemes(NodesInfo,"\n")
-                                   end,
+                ClusterNodesList = [CNEL || CNEL <- binary:split(NodesInfo,<<"\n">>, [global]), CNEL =/= <<>>],
                 NodeIdsL = lists:foldl(fun(ClusterNode, Acc) ->
-                               ClusterNodeI = case OTPRel < 20 of
-                                                  true ->  string:tokens(ClusterNode," ");
-                                                  false -> string:lexemes(ClusterNode," ")
-                                              end,
+                               ClusterNodeI = binary:split(ClusterNode,<<" ">>, [global]),
                                case lists:nth(3, ClusterNodeI) of
                                    Role when Role == <<"myself,master">>;
                                              Role == <<"master">> ->
-                                       [Ip, Port] = case OTPRel < 20 of
-                                                  true ->  string:tokens(lists:nth(2, ClusterNodeI), ":");
-                                                  false -> string:lexemes(lists:nth(2, ClusterNodeI), ":")
-                                              end,
+                                       [Ip, Port] = binary:split(lists:nth(2, ClusterNodeI), <<":">>, [global]),
                                        Pool = list_to_atom(binary_to_list(Ip) ++ "#" ++ binary_to_list(Port)),
                                        [{binary_to_list(lists:nth(1, ClusterNodeI)), Pool} | Acc];
                                    _ ->

--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -211,7 +211,7 @@ basic_test_() ->
                       ({error, <<"ASK ", _/binary>>}) -> true;
                       (_) -> false
                    end,
-                Verdict = case lists:any(Fun, Result) of
+                Verdict = case lists:all(Fun, Result) of
                     false -> Result;
                     true -> true
                 end,

--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -171,6 +171,56 @@ basic_test_() ->
                 ?assertEqual(none, proplists:lookup(error,eredis_cluster:qa(["cluster", "slots"]))),
                 ?assertMatch({error,_}, proplists:lookup(error,eredis_cluster:qa(["get", "qrs"])))
             end
+            },
+
+            { "ASK support",
+            fun () ->
+                Key = "{1}:test",
+                eredis_cluster:q(["set",Key]),
+                {ok, NodesInfo} = eredis_cluster:q(["cluster","nodes"]),
+
+                ClusterNodesList = string:lexemes(NodesInfo,"\n"),
+                NodeIdsL = lists:foldl(fun(ClusterNode, Acc) ->
+                                               ClusterNodeI = string:lexemes(ClusterNode," "),
+                                               case lists:nth(3, ClusterNodeI) of
+                                                   Role when Role == <<"myself,master">>;
+                                                             Role == <<"master">> ->
+                                                       [Ip, Port] = string:lexemes(lists:nth(2, ClusterNodeI), ":"),
+                                                       Pool = list_to_atom(binary_to_list(Ip) ++ "#" ++ binary_to_list(Port)),
+                                                       [{binary_to_list(lists:nth(1, ClusterNodeI)), Pool} | Acc];
+                                                   _ ->
+                                                       Acc
+                                               end
+                                       end, [], ClusterNodesList),
+                KeySlot = eredis_cluster:get_key_slot(Key),
+
+                Pool = element(1, eredis_cluster_monitor:get_pool_by_slot(KeySlot)),
+
+                {NodeId, Pool} = lists:keyfind(Pool, 2, NodeIdsL),
+                [{NodeId2, _Pool2}, _] = [{NI, P} || {NI, P} <- NodeIdsL, {NI, P} =/= {NodeId, Pool}],
+
+                %% Migrate Slot to have 2 sets of slots for one node:
+                CmdImp = ["CLUSTER", "SETSLOT", KeySlot, "IMPORTING", NodeId],
+                eredis_cluster:qa(CmdImp),
+
+                CmdMig = ["CLUSTER", "SETSLOT", KeySlot, "MIGRATING", NodeId2],
+                eredis_cluster:qa(CmdMig),
+                Result = lists:usort(eredis_cluster:qa(["get",Key])),
+
+                Fun = fun({error, <<"MOVED ", _/binary>>}) -> true;
+                      ({error, <<"ASK ", _/binary>>}) -> true;
+                      (_) -> false
+                   end,
+                Verdict = case lists:any(Fun, Result) of
+                    false -> Result;
+                    true -> true
+                end,
+                
+                ?assertEqual(true, Verdict),
+
+                CmdMig1 = ["CLUSTER", "SETSLOT", KeySlot, "NODE", NodeId2],
+                eredis_cluster:qa(CmdMig1)
+            end
             }
       ]
     }

--- a/test/eredis_cluster_tests.erl
+++ b/test/eredis_cluster_tests.erl
@@ -163,8 +163,15 @@ basic_test_() ->
                 eredis_cluster:eval(Script, ScriptHash, ["qrs"], ["evaltest"]),
                 ?assertEqual({ok, <<"evaltest">>}, eredis_cluster:q(["get", "qrs"]))
             end
-            }
+            },
 
+            { "get info from all pools",
+            fun () ->
+                ?assertEqual({ok, <<"evaltest">>}, eredis_cluster:q(["get", "qrs"])),
+                ?assertEqual(none, proplists:lookup(error,eredis_cluster:qa(["cluster", "slots"]))),
+                ?assertMatch({error,_}, proplists:lookup(error,eredis_cluster:qa(["get", "qrs"])))
+            end
+            }
       ]
     }
 }.


### PR DESCRIPTION
These changes have been implemented in the scope of Redis DB solution integration to the cloud infrastructure for a products of one of the world leading providers of Information and Communication Technologies.

Description:
a.	Retry the query that is sent to all connected pools (Redis instances);
b.	Add `refresh slots map and retry query` logic for such Redis error
        responses as <<"ASK ", _/binary>>,  <<"TRYAGAIN ", _/binary>> and
        <<"CLUSTERDOWN ", _/binary>>;
c.	Return an error to application in case of Redis response errors
        like as: "ERR unknown command 'foobar'” or "WRONGTYPE Operation
        against a key holding the wrong kind of value", "BUSY Redis is
        busy running a script", "NOAUTH Authentication required." and so on ;
d.	Add `refresh slots map and retry query ` logic in case of POSIX
        error that can related to temporary TCP issues.