### PR TITLE
Fix loading eredis and poolboy when compiled with rebar3

### DIFF
--- a/src/eredis_cluster.app.src
+++ b/src/eredis_cluster.app.src
@@ -5,7 +5,9 @@
     {registered, []},
     {applications, [
         kernel,
-        stdlib
+        stdlib,
+        eredis,
+        poolboy
     ]},
     {mod, {eredis_cluster, []}},
     {env, []}


### PR DESCRIPTION
eredis has to be loaded before eredis_cluster starts. poolboy has to be
started as well.

mix.exs lists eredis and poolboy among applications. The rebar3 equivalent is
adding eredis and poolboy to applications in eredis_cluster.app.src.