### PR TITLE
Remove the option to set logical database

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ Or:
 	        ]},
 	        {pool_size, 5},
 	        {pool_max_overflow, 0},
-		{database, 0},
- 		{password, "redis_pw"}
+	        {password, "redis_pw"}
 	    ]
 	}
 

--- a/src/eredis_cluster_monitor.erl
+++ b/src/eredis_cluster_monitor.erl
@@ -26,6 +26,7 @@
 }).
 
 -define(SLOTS, eredis_cluster_monitor_slots).
+-define(DATABASE, 0).
 
 %% API.
 -spec start_link() -> {ok, pid()}.
@@ -176,11 +177,10 @@ connect_node(Node) ->
             undefined
     end.
 
-safe_eredis_start_link(Address,Port) ->
+safe_eredis_start_link(Address, Port) ->
     process_flag(trap_exit, true),
-    DataBase = application:get_env(eredis_cluster, database, 0),
     Password = application:get_env(eredis_cluster, password, ""),
-    Payload = eredis:start_link(Address, Port, DataBase, Password),
+    Payload = eredis:start_link(Address, Port, ?DATABASE, Password),
     process_flag(trap_exit, false),
     Payload.
 

--- a/src/eredis_cluster_pool.erl
+++ b/src/eredis_cluster_pool.erl
@@ -19,16 +19,14 @@ create(Host, Port) ->
 
     case whereis(PoolName) of
         undefined ->
-            DataBase = application:get_env(eredis_cluster, database, 0),
             Password = application:get_env(eredis_cluster, password, ""),
             WorkerArgs = [{host, Host},
                           {port, Port},
-                          {database, DataBase},
                           {password, Password}
                          ],
 
-        	Size = application:get_env(eredis_cluster, pool_size, 10),
-        	MaxOverflow = application:get_env(eredis_cluster, pool_max_overflow, 0),
+            Size = application:get_env(eredis_cluster, pool_size, 10),
+            MaxOverflow = application:get_env(eredis_cluster, pool_max_overflow, 0),
 
             PoolArgs = [{name, {local, PoolName}},
                         {worker_module, eredis_cluster_pool_worker},

--- a/src/eredis_cluster_pool_worker.erl
+++ b/src/eredis_cluster_pool_worker.erl
@@ -16,17 +16,18 @@
 
 -record(state, {conn}).
 
+-define(DATABASE, 0).
+
 start_link(Args) ->
     gen_server:start_link(?MODULE, Args, []).
 
 init(Args) ->
     Hostname = proplists:get_value(host, Args),
     Port = proplists:get_value(port, Args),
-    DataBase = proplists:get_value(database, Args, 0),
     Password = proplists:get_value(password, Args, ""),
 
     process_flag(trap_exit, true),
-    Result = eredis:start_link(Hostname,Port, DataBase, Password),
+    Result = eredis:start_link(Hostname, Port, ?DATABASE, Password),
     process_flag(trap_exit, false),
 
     Conn = case Result of

--- a/test.config
+++ b/test.config
@@ -6,7 +6,6 @@
         ]},
         {pool_size, 5},
         {pool_max_overflow, 0},
-        {database, 0},
         {password, ""}
     ]
 }].


### PR DESCRIPTION
It's not possible to set a logical database when in cluster mode
and doing so will result in an error, see:
https://redis.io/commands/select

"When using Redis Cluster, the SELECT command cannot be used,
 since Redis Cluster only supports database zero."